### PR TITLE
Bugfix/frontend/members were stored globally

### DIFF
--- a/showtime-squad_frontend/src/pages/Groups/GroupJoiners.jsx
+++ b/showtime-squad_frontend/src/pages/Groups/GroupJoiners.jsx
@@ -4,8 +4,6 @@ import { postRequest } from "../../utils/GenericHTTPMethods"
 import FunctionButton from "../../components/atoms/FunctionButton"
 import './GroupJoiners.scss'
 
-const joinerSig = signal()
-
 const apiUrl = import.meta.env.VITE_REACT_APP_BACKEND_BASE_URL
 
 function GroupJoiners({ group }) {
@@ -17,7 +15,9 @@ function GroupJoiners({ group }) {
         )
     }
 
-    if (!joinerSig.value) {
+    let joinerSig
+    if (!joinerSig || !joinerSig.value) {
+        joinerSig = signal()
         joinerSig.value = group.joinRequests
     }
 

--- a/showtime-squad_frontend/src/pages/Groups/GroupMembers.jsx
+++ b/showtime-squad_frontend/src/pages/Groups/GroupMembers.jsx
@@ -4,13 +4,14 @@ import { postRequest } from '../../utils/GenericHTTPMethods'
 import FunctionButton from "../../components/atoms/FunctionButton"
 
 import './GroupMembers.scss'
-const usersSig = signal()
 
 const apiUrl = import.meta.env.VITE_REACT_APP_BACKEND_BASE_URL
 
 function GroupMembers({ group, username }) {
 
-    if (!usersSig.value) {
+    let usersSig
+    if (!usersSig || !usersSig.value) {
+        usersSig = signal()
         usersSig.value = group.users
     }
 

--- a/showtime-squad_frontend/src/pages/Groups/GroupNews.jsx
+++ b/showtime-squad_frontend/src/pages/Groups/GroupNews.jsx
@@ -6,13 +6,14 @@ import AddNewsModal from "./AddNewsModal"
 import FunctionButton from "../../components/atoms/FunctionButton"
 
 import './GroupNews.scss'
-const newsSig = signal()
 
 const apiUrl = import.meta.env.VITE_REACT_APP_BACKEND_BASE_URL
 
 function GroupNews({ group }) {
 
-    if (!newsSig.value) {
+    let newsSig
+    if (!newsSig || !newsSig.value) {
+        newsSig = signal()
         newsSig.value = group.news
     }
 


### PR DESCRIPTION
fixed the visual of group members persisting into any subsequently opened groups. This problem was present for group's lists of members, join requests, and news. All of them should be now fixed.