### PR TITLE
init roles enum rows into roles if they dont exist

### DIFF
--- a/showtime-squad_backend/pom.xml
+++ b/showtime-squad_backend/pom.xml
@@ -87,6 +87,12 @@
             <version>0.11.5</version>
             <scope>runtime</scope>
         </dependency>
+
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/showtime-squad_backend/src/main/java/com/showtimesquad/showtimesquad/service/RoleInitializationService.java
+++ b/showtime-squad_backend/src/main/java/com/showtimesquad/showtimesquad/service/RoleInitializationService.java
@@ -1,0 +1,28 @@
+package com.showtimesquad.showtimesquad.service;
+
+import com.showtimesquad.showtimesquad.enums.ERole;
+import com.showtimesquad.showtimesquad.model.Role;
+import com.showtimesquad.showtimesquad.repository.RoleRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.util.Arrays;
+
+@Service
+public class RoleInitializationService {
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @PostConstruct
+    public void initRoles() {
+        // Check if roles already exist in the database
+        if (roleRepository.count() == 0) {
+            // Roles don't exist, insert them
+            Arrays.stream(ERole.values())
+                    .map(Role::new)
+                    .forEach(roleRepository::save);
+        }
+    }
+}


### PR DESCRIPTION
This is so that when running a fresh project, creating a user would fail because rows in roles did not exist, and they would've been needed to be inserted into the database manually.